### PR TITLE
Fetch all git history, restore old scripts

### DIFF
--- a/.github/workflows/onmerge.yml
+++ b/.github/workflows/onmerge.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -46,6 +48,8 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -43,6 +45,8 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -50,6 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: go mod download
+      - run: echo "test"
       - run: make bootstrap
       - run: |
           export CONTROLLER_TAG="premerge-$(git rev-parse --short HEAD)"
@@ -59,12 +64,11 @@ jobs:
           export GOPATH=$(pwd)/go
           ./script/pull-or-build-image.sh function-controller
           ./script/pull-or-build-image.sh function-image-builder
-          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"   
+          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" || echo "Only repo editors can push images"
           images=( 
             $CONTROLLER_IMAGE_NAME
             $BUILDER_IMAGE_NAME 
           )
           for image in "${images[@]}"; do
-            echo "Pulling ${image}:${CONTROLLER_TAG}"
-            docker push ${image}:${CONTROLLER_TAG}
+            docker push ${image}:${CONTROLLER_TAG} || echo "Only repo editors can push images"
           done

--- a/script/binary
+++ b/script/binary
@@ -16,9 +16,8 @@
 
 set -e
 
-# NOTE: upstream uses "git describe --tags --dirty" which doesn't seem to work on github
-#       action builders.
-GIT_COMMIT=$(git rev-parse --short HEAD)
+
+GIT_COMMIT=$(git describe --tags --dirty)
 BUILD_FLAGS=(-ldflags="-w -X github.com/kubeless/kubeless/pkg/version.Version=${GIT_COMMIT}")
 
 # Get rid of existing binary

--- a/script/binary-controller
+++ b/script/binary-controller
@@ -42,9 +42,7 @@ else
 fi
 
 
-# NOTE: upstream uses "git describe --tags --dirty" which doesn't seem to work on github
-#       action builders.
-GIT_COMMIT=$(git rev-parse --short HEAD)
+GIT_COMMIT=$(git describe --tags --dirty)
 BUILD_FLAGS=(-ldflags="-w -X github.com/kubeless/kubeless/pkg/version.Version=${GIT_COMMIT}")
 
 # Get rid of existing binaries


### PR DESCRIPTION
Override default github action behavior to do a shallow clone, this allows us to maintain the original version of the helper scripts.