### PR TITLE
INTERSIGHT-18913: Skipping the getannotation as it uses unsupported k…

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -872,27 +872,37 @@ func getConfigLocation(apiExtensionsClientset clientsetAPIExtensions.Interface) 
 	configLocation := ConfigLocation{}
 	controllerNamespace := os.Getenv("KUBELESS_NAMESPACE")
 	kubelessConfig := os.Getenv("KUBELESS_CONFIG")
+	/*
+		annotationsCRD, err := GetAnnotationsFromCRD(apiExtensionsClientset, "functions.kubeless.io")
+		if err != nil {
+			return configLocation, err
+		}
+		if len(controllerNamespace) == 0 {
+			if ns, ok := annotationsCRD["kubeless.io/namespace"]; ok {
+				controllerNamespace = ns
+			} else {
+				controllerNamespace = "kubeless"
+			}
+		}
+		if len(kubelessConfig) == 0 {
+			if config, ok := annotationsCRD["kubeless.io/config"]; ok {
+				kubelessConfig = config
+			} else {
+				kubelessConfig = "kubeless-config"
+			}
+		}
+	*/
 
-	annotationsCRD, err := GetAnnotationsFromCRD(apiExtensionsClientset, "functions.kubeless.io")
-	if err != nil {
-		return configLocation, err
-	}
 	if len(controllerNamespace) == 0 {
-		if ns, ok := annotationsCRD["kubeless.io/namespace"]; ok {
-			controllerNamespace = ns
-		} else {
-			controllerNamespace = "kubeless"
-		}
+		configLocation.Namespace = "kubeless"
+	} else {
+		configLocation.Namespace = controllerNamespace
 	}
-	configLocation.Namespace = controllerNamespace
 	if len(kubelessConfig) == 0 {
-		if config, ok := annotationsCRD["kubeless.io/config"]; ok {
-			kubelessConfig = config
-		} else {
-			kubelessConfig = "kubeless-config"
-		}
+		configLocation.Name = "kubeless-config"
+	} else {
+		configLocation.Name = kubelessConfig
 	}
-	configLocation.Name = kubelessConfig
 	return configLocation, nil
 }
 


### PR DESCRIPTION
…8s API call that is enforced in v1.22

**Issue Ref**: INTERSIGHT-18913
 
Following error is reported in kubeless-function-controller after k8s upgrade to v1.22.  This is because 'client.authentication.k8s.io/v1beta1' is not supported anymore.  

    "stderr": "time=\"2023-03-02T21:49:50Z\" level=fatal msg=\"Can not create out-of-cluster client: exec plugin: invalid apiVersion \\\"client.authentication.k8s.io/v1beta1\\\"\"",
 

[PR Description]

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
